### PR TITLE
Adds stopped state to docs

### DIFF
--- a/docs/In Depth Guides/2-web-hooks.md
+++ b/docs/In Depth Guides/2-web-hooks.md
@@ -207,6 +207,7 @@ Event | Description
  `tracking_request.succeeded` | Shipment created and linked to `TrackingRequest`
  `tracking_request.failed` | `TrackingRequest` failed and shipment was not created
  `tracking_request.awaiting_manifest` | `TrackingRequest` awaiting a manifest
+ `tracking_request.tracking_stopped` | Terminal49 is no longer updating this `TrackingRequest`
  `container.transport.empty_out` | Empty out at port of lading (origin)
  `container.transport.full_in` | Full in at port of lading 
  `container.transport.vessel_loaded` | Vessel loaded at port of lading 

--- a/docs/In Depth Guides/2-web-hooks.md
+++ b/docs/In Depth Guides/2-web-hooks.md
@@ -207,7 +207,7 @@ Event | Description
  `tracking_request.succeeded` | Shipment created and linked to `TrackingRequest`
  `tracking_request.failed` | `TrackingRequest` failed and shipment was not created
  `tracking_request.awaiting_manifest` | `TrackingRequest` awaiting a manifest
- `tracking_request.tracking_stopped` | Terminal49 is no longer updating this `TrackingRequest`
+ `tracking_request.tracking_stopped` | Terminal49 is no longer updating this `TrackingRequest`. \* Going live 2022-01-20
  `container.transport.empty_out` | Empty out at port of lading (origin)
  `container.transport.full_in` | Full in at port of lading 
  `container.transport.vessel_loaded` | Vessel loaded at port of lading 

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -37,6 +37,15 @@ Temporary reasons can become permanent when the `status` changes to `failed`:
  * `invalid_number` if the shipping line rejects the formatting of the number.
  * `booking_cancelled` if the shipping line indicates that the booking has been cancelled.
 
+## Stopped
+
+Terminal49 will stop tracking requests for the following reasons:
+
+ * When all cargo is marked `empty_returned`.
+ * For Maersk: all cargo is marked `empty_returned` or `picked_up`.
+ * If more than 56 days have passed since the cargo arrived at it's destination.
+ * If there have been no updates for more than 56 days.
+
 ## Status
 
 If you want to see the status of your tracking request you can make a [GET request](https://developers.terminal49.com/docs/api/docs/reference/terminal49/terminal49.v1.json/paths/~1tracking_requests~1%7Bid%7D/get) on what the most recent failure reason was (`failed_reason` field).

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -24,7 +24,6 @@ The `failed_reason` field can take one of the following temporary values:
  * `unrecognized_response` when we could not parse the response from the shipping line, 
  * `shipping_line_unreachable` if the shipping line was unreachable,
  * `internal_processing_error` when we faced other issue,
- * `not_found` if the shipping line could not find the booking number.
  * `awaiting_manifest` if the shipping line indidicates a BL number is found, but data is not yet available.
 
 ### Permanent

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -44,8 +44,8 @@ Temporary reasons can become permanent when the `status` changes to `failed`:
 Terminal49 will stop tracking requests for the following reasons:
 
  * The booking was cancelled.
- * When all cargo is marked `empty_returned`.
- * For Maersk: all cargo is marked `empty_returned` or `picked_up`.
+ * When all containers are marked `empty_returned`.
+ * For Maersk: all containers are marked `empty_returned` or `picked_up`.
  * If more than 56 days have passed since the cargo arrived at it's destination.
  * If there have been no updates for more than 56 days.
 

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -37,18 +37,20 @@ Temporary reasons can become permanent when the `status` changes to `failed`:
  * `invalid_number` if the shipping line rejects the formatting of the number.
  * `booking_cancelled` if the shipping line indicates that the booking has been cancelled.
 
-## Stopped
+## Stopped 
 
 \* Going live 2022-01-20
+
+When a shipment is no longer being updated then the tracking request status is marked as tracking_stopped
 
 Terminal49 will stop tracking requests for the following reasons:
 
  * The booking was cancelled.
- * When all containers are marked `empty_returned`.
- * For Maersk: all containers are marked `empty_returned` or `picked_up`.
- * If more than 56 days have passed since the cargo arrived at it's destination.
- * If there have been no updates for more than 56 days.
+ * All shipment containers are marked `empty_returned`.
+ * For Maersk: all shipment containers are marked `empty_returned` or `picked_up`.
+ * More than 56 days have passed since the shipment arrived at it's destination.
+ * There have been no updates from the shipping line for more than 56 days.
 
-## Status
+## Retrieving Status
 
 If you want to see the status of your tracking request you can make a [GET request](https://developers.terminal49.com/docs/api/docs/reference/terminal49/terminal49.v1.json/paths/~1tracking_requests~1%7Bid%7D/get) on what the most recent failure reason was (`failed_reason` field).

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -1,4 +1,4 @@
-# Tracking Request Retrying
+# Tracking Request Lifecycle
 
 When you submit a tracking request your request is added to our queue to being checked at the shipping line. So what happens if the request doesn't go through correctly?
 

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -41,6 +41,7 @@ Temporary reasons can become permanent when the `status` changes to `failed`:
 
 Terminal49 will stop tracking requests for the following reasons:
 
+ * The booking was cancelled.
  * When all cargo is marked `empty_returned`.
  * For Maersk: all cargo is marked `empty_returned` or `picked_up`.
  * If more than 56 days have passed since the cargo arrived at it's destination.

--- a/docs/In Depth Guides/4-tracking-request-lifecycle.md
+++ b/docs/In Depth Guides/4-tracking-request-lifecycle.md
@@ -39,6 +39,8 @@ Temporary reasons can become permanent when the `status` changes to `failed`:
 
 ## Stopped
 
+\* Going live 2022-01-20
+
 Terminal49 will stop tracking requests for the following reasons:
 
  * The booking was cancelled.

--- a/docs/reference/terminal49/terminal49.v1.json
+++ b/docs/reference/terminal49/terminal49.v1.json
@@ -2038,7 +2038,7 @@
                             "pod_full_out_at": null,
                             "empty_terminated_at": null
                           },
-                          "relation ships": {
+                          "relationships": {
                             "shipment": {
                               "data": {
                                 "id": "b5b10c0a-8d18-46da-b4c2-4e5fa790e7da",
@@ -4881,9 +4881,9 @@
                 "enum": [
                   "all_containers_terminated",
                   "past_arrival_window",
-                  "not_found_at_line",
                   "no_updates_at_line",
-                  "cancelled_by_user"
+                  "cancelled_by_user",
+                  "booking_cancelled"
                 ],
                 "description": "The reason Terminal49 stopped checking",
                 "nullable": true
@@ -5464,7 +5464,8 @@
                   "pending",
                   "awaiting_manifest",
                   "created",
-                  "failed"
+                  "failed",
+                  "tracking_stopped"
                 ]
               },
               "failed_reason": {


### PR DESCRIPTION
This PR adds the following:

- Adds note about T49 no longer updating the tracking request when status is `tracking_request.stopped`
- Renames title of "Tracking Request Retrying" -> "Tracking Request Lifecycle"
- Moves "Tracking Request Lifecycle" page under "In-depth guides"
- Adds section about stopped state to bottom of "Tracking Request Lifecycle" page
- Removes `not_found` from list of temporary reasons
